### PR TITLE
Version bump to 0.1.1+1 to support shelf>=0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.pub/
 *packages
 pubspec.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1+1
+
+* support for shelf version <0.7.0
+* switch tentacle_response_formatter to shelf_response_formatter as latter supports shelf >=0.6.0
+* deprecated unittest package replaced with test package
+
 ## 0.1.1
 
 * added optional detail argument to exception constructors to allow additional

--- a/lib/exception_response.dart
+++ b/lib/exception_response.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf_exception_response/exception.dart';
 export 'package:shelf_exception_response/exception.dart';
-import 'package:tentacle_response_formatter/formatter.dart';
+import 'package:shelf_response_formatter/shelf_response_formatter.dart';
 import 'dart:io' show HttpHeaders;
 
 ResponseFormatter formatter = new ResponseFormatter();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: shelf_exception_response
-version: 0.1.1
+version: 0.1.1+1
 description: Shelf middleware that provides the abillity to simply throw an HttpException that gets converted to an appropriate response code and a formatted response body dependent on the clients accept header.
 homepage: https://github.com/octobyte/shelf_exception_response
 author: Thomas Profelt <tom@octobyte.at>
 
 dependencies:
-  shelf: ">=0.5.0+1 <0.6.0"
-  tentacle_response_formatter: ">=0.1.0 <0.2.0"
+  shelf: ">=0.5.0+1 <0.7.0"
+  shelf_response_formatter: ">=0.1.0 <0.2.0"
 
 dev_dependencies:
-  unittest: any
+  test: any
 
 environment:
   sdk: ">=1.3.0"

--- a/test/ExceptionResponseTest.dart
+++ b/test/ExceptionResponseTest.dart
@@ -1,7 +1,7 @@
 library shelf_exception_response.test.exception_response;
 
 import 'dart:async';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf_exception_response/exception_response.dart';
 


### PR DESCRIPTION
Proposing these changes to make it possible working with shelf versions 0.6.0 and above.
No significant changes are needed, all tests are passing ok
